### PR TITLE
Fix normalize for empty mark tags

### DIFF
--- a/lib/normalize/handle-whitespace.js
+++ b/lib/normalize/handle-whitespace.js
@@ -7,7 +7,7 @@ const normalizeWhitespace = content => {
 
 const handleWhitespace = tree => {
   tree.forEach(obj => {
-    if (obj.type === 'text') {
+    if (obj.type === 'text' && obj.content) {
       obj.content = normalizeWhitespace(obj.content);
     } else if (obj.children) {
       handleWhitespace(obj.children);

--- a/lib/normalize/merge-text-nodes.js
+++ b/lib/normalize/merge-text-nodes.js
@@ -8,7 +8,7 @@ const mergeTextNodes = (sameTypeTextNodes, tree) => {
   tree.forEach(node => {
     if (node.type === 'text') {
       if (textNode) {
-        if (sameTypeTextNodes(textNode, node)) {
+        if (sameTypeTextNodes(textNode, node) && !node.mark) {
           textNode.content = textNode.content + node.content;
         } else {
           merged.push(textNode);

--- a/lib/normalize/merge-text-nodes.js
+++ b/lib/normalize/merge-text-nodes.js
@@ -8,7 +8,7 @@ const mergeTextNodes = (sameTypeTextNodes, tree) => {
   tree.forEach(node => {
     if (node.type === 'text') {
       if (textNode) {
-        if (sameTypeTextNodes(textNode, node) && !node.mark) {
+        if (sameTypeTextNodes(textNode, node) && !textNode.mark && !node.mark) {
           textNode.content = textNode.content + node.content;
         } else {
           merged.push(textNode);

--- a/lib/normalize/minimum-content.js
+++ b/lib/normalize/minimum-content.js
@@ -1,5 +1,5 @@
 const hasNoContentNodes = children => children.every(child => {
-  return child.type !== 'text' && child.type !== 'linebreak';
+  return (child.mark && !child.content) || (child.type !== 'text' && child.type !== 'linebreak');
 });
 
 const assureMinimumContent = node => {

--- a/lib/normalize/remove-extra-linebreaks.js
+++ b/lib/normalize/remove-extra-linebreaks.js
@@ -1,7 +1,8 @@
 const shouldRemoveLinebreak = children => {
   return children[children.length - 1].type === 'linebreak' &&
     children[children.length - 2] &&
-    children[children.length - 2].type !== 'linebreak';
+    children[children.length - 2].type !== 'linebreak' &&
+    !isEmptyMarkNode(children[children.length - 2]);
 };
 
 export default tree => {
@@ -11,3 +12,7 @@ export default tree => {
     }
   });
 };
+
+function isEmptyMarkNode (node) {
+  return node.mark && !node.content;
+}

--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -23,9 +23,8 @@ export default opts => {
         elementNode(elm, textOpts, result);
       }
 
-      // TEXT_NODE or empty MARK
-      if ((elm.nodeName === '#text' && elm.data.length > 0) ||
-        (elm.tagName && elm.tagName.toLowerCase() === 'mark' && elm.childNodes.length === 0)) {
+      // TEXT_NODE
+      if (elm.nodeName === '#text' && elm.data.length > 0) {
         result.push(text(textOpts, elm));
       }
     }
@@ -50,6 +49,12 @@ export default opts => {
     const blockElementResult = blockElement(elm, textOpts);
     if (blockElementResult) {
       result.push(blockElementResult);
+      return;
+    }
+
+    const emptyMark = elm.tagName.toLowerCase() === 'mark' && elm.childNodes.length === 0;
+    if (emptyMark) {
+      result.push(text(textOpts, elm));
       return;
     }
 

--- a/lib/text-formattings.js
+++ b/lib/text-formattings.js
@@ -1,7 +1,7 @@
 const defaultTextFormattings = [
   {
     property: 'content',
-    get: elm => elm.nodeName === '#text' && elm.data
+    get: elm => (elm.nodeName === '#text' && elm.data) || null
   },
   {
     property: 'href',
@@ -44,7 +44,7 @@ const defaultTextFormattings = [
     classProperty: 'markClass',
     getClass: elm => {
       if (!elm.tagName || elm.tagName.toLowerCase() !== 'mark') {
-        return '';
+        return null;
       }
 
       return elm.getAttribute('class');

--- a/test/custom-test.js
+++ b/test/custom-test.js
@@ -21,7 +21,7 @@ test('custom text formattings: add underline span-type', t => {
         {
           type: 'text',
           mark: false,
-          markClass: '',
+          markClass: null,
           content: 'foo',
           href: null,
           italic: false,
@@ -31,7 +31,7 @@ test('custom text formattings: add underline span-type', t => {
         {
           type: 'text',
           mark: false,
-          markClass: '',
+          markClass: null,
           content: 'bar',
           href: null,
           italic: false,

--- a/test/normalize-test.js
+++ b/test/normalize-test.js
@@ -124,9 +124,27 @@ test('normalize() keep all empty mark-tags', t => {
   const expected = [{
     type: 'paragraph',
     children: [
+      { type: 'linebreak' },
       { type: 'text', mark: true, markClass: 'mark1', content: null },
-      { type: 'text', mark: true, markClass: 'mark2', content: null },
-      { type: 'linebreak' }
+      { type: 'text', mark: true, markClass: 'mark2', content: null }
+    ]
+  }];
+
+  t.same(normalize(tree), expected);
+});
+
+test('normalize() dont add minimum content linebreak for mark tag with content', t => {
+  const tree = [{
+    type: 'paragraph',
+    children: [
+      { type: 'text', mark: true, markClass: 'mark1', content: 'beep boop' }
+    ]
+  }];
+
+  const expected = [{
+    type: 'paragraph',
+    children: [
+      { type: 'text', mark: true, markClass: 'mark1', content: 'beep boop' }
     ]
   }];
 

--- a/test/normalize-test.js
+++ b/test/normalize-test.js
@@ -111,3 +111,56 @@ test('normalize() add br-tag to empty text-container', t => {
 
   t.same(normalize(tree), expected);
 });
+
+test('normalize() keep all empty mark-tags', t => {
+  const tree = [{
+    type: 'paragraph',
+    children: [
+      { type: 'text', mark: true, markClass: 'mark1', content: null },
+      { type: 'text', mark: true, markClass: 'mark2', content: null }
+    ]
+  }];
+
+  const expected = [{
+    type: 'paragraph',
+    children: [
+      { type: 'text', mark: true, markClass: 'mark1', content: null },
+      { type: 'text', mark: true, markClass: 'mark2', content: null },
+      { type: 'linebreak' }
+    ]
+  }];
+
+  t.same(normalize(tree), expected);
+});
+
+test('normalize() don\'t remove br tags in-between mark with content', t => {
+  const tree = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'foo bar'
+    }, {
+      type: 'linebreak'
+    }, {
+      type: 'text',
+      mark: true,
+      content: 'beep boop'
+    }]
+  }];
+  const expected = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'foo bar'
+    }, {
+      type: 'linebreak'
+    }, {
+      type: 'text',
+      mark: true,
+      content: 'beep boop'
+    }]
+  }];
+  const actual = normalize(tree);
+
+  t.same(actual, expected);
+});

--- a/test/parse-normalize-fixtures/basic.json
+++ b/test/parse-normalize-fixtures/basic.json
@@ -4,7 +4,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "Top header",
       "href": null,
       "bold": false,
@@ -15,7 +15,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "Second level",
       "href": null,
       "bold": false,
@@ -26,7 +26,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "beepboop",
       "href": null,
       "bold": false,

--- a/test/parse-normalize-fixtures/blockquote.json
+++ b/test/parse-normalize-fixtures/blockquote.json
@@ -8,7 +8,7 @@
           {
             "type": "text",
             "mark": false,
-            "markClass": "",
+            "markClass": null,
             "content": "beep boop",
             "href": null,
             "italic": false,
@@ -27,7 +27,7 @@
           {
             "type": "text",
             "mark": false,
-            "markClass": "",
+            "markClass": null,
             "content": "beep boop",
             "href": null,
             "italic": false,
@@ -46,7 +46,7 @@
           {
             "type": "text",
             "mark": false,
-            "markClass": "",
+            "markClass": null,
             "content": "this",
             "href": null,
             "italic": false,
@@ -55,7 +55,7 @@
           {
             "type": "text",
             "mark": false,
-            "markClass": "",
+            "markClass": null,
             "content": "is",
             "href": null,
             "italic": false,
@@ -64,7 +64,7 @@
           {
             "type": "text",
             "mark": false,
-            "markClass": "",
+            "markClass": null,
             "content": "styled",
             "href": null,
             "italic": false,
@@ -83,7 +83,7 @@
           {
             "type": "text",
             "mark": false,
-            "markClass": "",
+            "markClass": null,
             "content": "this works as well",
             "href": null,
             "italic": false,
@@ -97,7 +97,7 @@
           {
             "type": "text",
             "mark": false,
-            "markClass": "",
+            "markClass": null,
             "content": "as expected",
             "href": null,
             "italic": false,

--- a/test/parse-normalize-fixtures/blocks.json
+++ b/test/parse-normalize-fixtures/blocks.json
@@ -4,7 +4,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "Divs are also text",
       "href": null,
       "bold": false,
@@ -15,7 +15,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "Some text",
       "href": null,
       "bold": false,
@@ -26,7 +26,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "Some text in a div",
       "href": null,
       "bold": false,
@@ -37,7 +37,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "And a header",
       "href": null,
       "bold": false,
@@ -48,7 +48,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "Text in a form",
       "href": null,
       "bold": false,

--- a/test/parse-normalize-fixtures/inline-css.json
+++ b/test/parse-normalize-fixtures/inline-css.json
@@ -4,7 +4,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "This is a link",
       "href": "http://link.com/",
       "bold": false,
@@ -12,7 +12,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": " ",
       "href": null,
       "bold": false,
@@ -20,7 +20,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "This is a bold link",
       "href": "http://link2.com/",
       "bold": true,
@@ -28,7 +28,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "This is also a bold link",
       "href": "http://link3.com/",
       "bold": true,
@@ -39,7 +39,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "This is italic and ",
       "href": null,
       "bold": false,
@@ -47,7 +47,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "this is a link",
       "href": "http://link4.com/",
       "bold": false,
@@ -55,7 +55,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": " foo bar",
       "href": "http://link4.com/",
       "bold": false,
@@ -66,7 +66,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "boldbold2bold3bold4",
       "href": null,
       "bold": true,
@@ -74,7 +74,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "italic",
       "href": null,
       "bold": false,
@@ -82,7 +82,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "STRONG",
       "href": null,
       "bold": true,
@@ -90,7 +90,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "EM",
       "href": null,
       "bold": false,

--- a/test/parse-normalize-fixtures/linebreak.json
+++ b/test/parse-normalize-fixtures/linebreak.json
@@ -5,7 +5,7 @@
       {
         "type": "text",
         "mark": false,
-        "markClass": "",
+        "markClass": null,
         "content": "beep",
         "href": null,
         "bold": false,
@@ -15,7 +15,7 @@
       }, {
         "type": "text",
         "mark": false,
-        "markClass": "",
+        "markClass": null,
         "content": "boop",
         "href": null,
         "bold": false,

--- a/test/parse-normalize-fixtures/mark.html
+++ b/test/parse-normalize-fixtures/mark.html
@@ -1,0 +1,1 @@
+<p><mark class="empty-mark-tag"></mark>Text<mark class='mark-class'>markcontent</mark></p>

--- a/test/parse-normalize-fixtures/mark.html
+++ b/test/parse-normalize-fixtures/mark.html
@@ -1,1 +1,3 @@
 <p><mark class="empty-mark-tag"></mark>Text<mark class='mark-class'>markcontent</mark></p>
+<p><mark class="mark-start"></mark><mark class="mark-end"></mark><br></p>
+<p><mark class="mark">markcontent</mark><br></p>

--- a/test/parse-normalize-fixtures/mark.json
+++ b/test/parse-normalize-fixtures/mark.json
@@ -25,4 +25,38 @@
     "type": "text"
   }],
   "type": "paragraph"
+},
+{
+  "children": [{
+    "bold": false,
+    "content": null,
+    "href": null,
+    "italic": false,
+    "mark": true,
+    "markClass": "mark-start",
+    "type": "text"
+  }, {
+    "bold": false,
+    "content": null,
+    "href": null,
+    "italic": false,
+    "mark": true,
+    "markClass": "mark-end",
+    "type": "text"
+  }, {
+    "type": "linebreak"
+  }],
+  "type": "paragraph"
+},
+{
+  "children": [{
+    "bold": false,
+    "content": "markcontent",
+    "href": null,
+    "italic": false,
+    "mark": true,
+    "markClass": "mark",
+    "type": "text"
+  }],
+  "type": "paragraph"
 }]

--- a/test/parse-normalize-fixtures/mark.json
+++ b/test/parse-normalize-fixtures/mark.json
@@ -1,0 +1,28 @@
+[{
+  "children": [{
+    "bold": false,
+    "content": null,
+    "href": null,
+    "italic": false,
+    "mark": true,
+    "markClass": "empty-mark-tag",
+    "type": "text"
+  }, {
+    "bold": false,
+    "content": "Text",
+    "href": null,
+    "italic": false,
+    "mark": false,
+    "markClass": null,
+    "type": "text"
+  }, {
+    "bold": false,
+    "content": "markcontent",
+    "href": null,
+    "italic": false,
+    "mark": true,
+    "markClass": "mark-class",
+    "type": "text"
+  }],
+  "type": "paragraph"
+}]

--- a/test/parse-normalize-fixtures/spans.json
+++ b/test/parse-normalize-fixtures/spans.json
@@ -4,7 +4,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "beep boop",
       "href": null,
       "bold": false,
@@ -15,7 +15,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "foo bar Hello, world!",
       "href": null,
       "bold": false,

--- a/test/parse-normalize-fixtures/whitespace.json
+++ b/test/parse-normalize-fixtures/whitespace.json
@@ -4,7 +4,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "Hello, world!",
       "href": null,
       "bold": false,
@@ -16,7 +16,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": " beepboop ",
       "href": null,
       "bold": false,
@@ -27,7 +27,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": " foo",
       "href": null,
       "bold": false,
@@ -35,7 +35,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "bar",
       "href": null,
       "bold": true,
@@ -43,7 +43,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": " ",
       "href": null,
       "bold": false,
@@ -51,7 +51,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": "bas",
       "href": null,
       "bold": false,
@@ -59,7 +59,7 @@
     }, {
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": " ",
       "href": null,
       "bold": false,
@@ -70,7 +70,7 @@
     "children": [{
       "type": "text",
       "mark": false,
-      "markClass": "",
+      "markClass": null,
       "content": " YEAH YEAH YEAHS",
       "href": null,
       "bold": false,

--- a/test/parse-normalize-test.js
+++ b/test/parse-normalize-test.js
@@ -60,6 +60,11 @@ createTest(
   fs.readFileSync(__dirname + '/parse-normalize-fixtures/embeds.html', 'utf8'),
   require('./parse-normalize-fixtures/embeds.json')
 );
+createTest(
+  'mark',
+  fs.readFileSync(__dirname + '/parse-normalize-fixtures/mark.html', 'utf8'),
+  require('./parse-normalize-fixtures/mark.json')
+);
 
 test('parseAndNormalize(elm)) whitespace', t => {
   t.same(parseAndNormalize('<p>\tbeep\tboop\t</p>'), [{
@@ -67,7 +72,7 @@ test('parseAndNormalize(elm)) whitespace', t => {
     children: [{
       type: 'text',
       mark: false,
-      markClass: '',
+      markClass: null,
       content: ' beep boop ',
       href: null,
       bold: false,
@@ -87,7 +92,7 @@ if (!process.browser) {
         {
           type: 'text',
           mark: false,
-          markClass: '',
+          markClass: null,
           content: 'flip flop',
           href: null,
           italic: false,

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -32,7 +32,7 @@ test('parse() text in span', t => {
     italic: false,
     type: 'text',
     mark: false,
-    markClass: ''
+    markClass: null
   }];
   t.same(actual, expected);
 });
@@ -75,8 +75,8 @@ test('parse() figure + img', t => {
     type: 'embed',
     embedType: 'image',
     caption: [
-      { bold: false, content: 'Hello, ', href: null, italic: false, type: 'text', mark: false, markClass: '' },
-      { bold: true, content: 'world', href: null, italic: false, type: 'text', mark: false, markClass: '' }
+      { bold: false, content: 'Hello, ', href: null, italic: false, type: 'text', mark: false, markClass: null },
+      { bold: true, content: 'world', href: null, italic: false, type: 'text', mark: false, markClass: null }
     ],
     src: 'http://example.com/image.jpg',
     width: null,
@@ -153,7 +153,7 @@ test('parse() figure with unknown content', t => {
       children: [{
         type: 'text',
         mark: false,
-        markClass: '',
+        markClass: null,
         content: 'beep',
         href: null,
         italic: false,
@@ -308,8 +308,8 @@ test('parse() figure + video with src & figcaption', t => {
     type: 'embed',
     embedType: 'video',
     caption: [
-      { bold: false, content: 'Hello, ', href: null, italic: false, type: 'text', mark: false, markClass: '' },
-      { bold: true, content: 'world', href: null, italic: false, type: 'text', mark: false, markClass: '' }
+      { bold: false, content: 'Hello, ', href: null, italic: false, type: 'text', mark: false, markClass: null },
+      { bold: true, content: 'world', href: null, italic: false, type: 'text', mark: false, markClass: null }
     ],
     sources: [{
       src: 'http://example.com/video.mp4',
@@ -354,8 +354,8 @@ test('parse() figure + youtube iframe', t => {
     type: 'embed',
     embedType: 'youtube',
     caption: [
-      { bold: false, content: 'Hello, ', href: null, italic: false, type: 'text', mark: false, markClass: '' },
-      { bold: true, content: 'world', href: null, italic: false, type: 'text', mark: false, markClass: '' }
+      { bold: false, content: 'Hello, ', href: null, italic: false, type: 'text', mark: false, markClass: null },
+      { bold: true, content: 'world', href: null, italic: false, type: 'text', mark: false, markClass: null }
     ],
     youtubeId: 'pDVmldTurqk'
   }];
@@ -645,7 +645,7 @@ test('parse() tricky link', t => {
       {
         type: 'text',
         mark: false,
-        markClass: '',
+        markClass: null,
         content: 'This is italic and ',
         href: null,
         italic: true,
@@ -654,7 +654,7 @@ test('parse() tricky link', t => {
       {
         type: 'text',
         mark: false,
-        markClass: '',
+        markClass: null,
         content: 'this is a link',
         href: 'http://link4.com/',
         italic: true,
@@ -663,7 +663,7 @@ test('parse() tricky link', t => {
       {
         type: 'text',
         mark: false,
-        markClass: '',
+        markClass: null,
         content: ' foo bar',
         href: 'http://link4.com/',
         italic: false,
@@ -697,7 +697,7 @@ test('parse() empty mark', t => {
     type: 'paragraph',
     children: [{
       bold: false,
-      content: false,
+      content: null,
       href: null,
       italic: false,
       mark: true,
@@ -709,7 +709,7 @@ test('parse() empty mark', t => {
       href: null,
       italic: false,
       mark: false,
-      markClass: '',
+      markClass: null,
       type: 'text'
     }]
   }];


### PR DESCRIPTION
Review: @kesla @iefserge 
Type: Patch

Empty mark tags (https://github.com/micnews/html-to-article-json/pull/42) was messing up the normalize step, this fixes that. And also makes sure we keep all mark tags. 
