### PR TITLE
expose embedAs object key for twitter video embeds

### DIFF
--- a/lib/parse/embeds.js
+++ b/lib/parse/embeds.js
@@ -35,11 +35,11 @@ const transformers = {
     user: user || null,
     id, text, url
   }),
-  twitter: ({url, date, user, id, text}) => ({
+  twitter: ({embedAs, url, date, user, id, text}) => ({
     type: 'embed',
     embedType: 'twitter',
     caption: [],
-    url, date, user, id, text
+    embedAs, url, date, user, id, text
   }),
   youtube: ({youtubeId}) => ({
     type: 'embed',

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "block-elements": "^1.1.0",
     "embedly-url": "^1.0.0",
-    "embeds": "git://github.com/mikelax/embeds.git",
+    "embeds": "^2.4.0",
     "es6-set": "^0.1.2",
     "generate-function": "^2.0.0",
     "get-youtube-id": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "block-elements": "^1.1.0",
     "embedly-url": "^1.0.0",
-    "embeds": "^2.4.0",
+    "embeds": "^2.5.0",
     "es6-set": "^0.1.2",
     "generate-function": "^2.0.0",
     "get-youtube-id": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "block-elements": "^1.1.0",
     "embedly-url": "^1.0.0",
-    "embeds": "^2.0.1",
+    "embeds": "git://github.com/mikelax/embeds.git",
     "es6-set": "^0.1.2",
     "generate-function": "^2.0.0",
     "get-youtube-id": "^1.0.0",

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -368,6 +368,30 @@ test('parse() tweet - normal', t => {
   const expected = [{
     type: 'embed',
     embedType: 'twitter',
+    embedAs: 'tweet',
+    caption: [],
+    text: [
+      { content: 'GIF vs. JIF… This ', href: null },
+      { content: 'pic.twitter.com/qFAHWgdbL6', href: 'https://t.co/qFAHWgdbL6' }
+    ],
+    url: 'https://twitter.com/MattNavarra/status/684690494841028608',
+    date: 'January 6, 2016',
+    user: {
+      slug: 'MattNavarra',
+      name: 'Matt (foo) Navarra'
+    },
+    id: '684690494841028608'
+  }];
+  t.same(actual, expected);
+});
+
+test('parse() tweet - video', t => {
+  const input = '<blockquote class="twitter-video" lang="en"><p lang="en" dir="ltr">GIF vs. JIF… This <a href="https://t.co/qFAHWgdbL6">pic.twitter.com/qFAHWgdbL6</a></p>&mdash; Matt (foo) Navarra (@MattNavarra) <a href="https://twitter.com/MattNavarra/status/684690494841028608">January 6, 2016</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>';
+  const actual = parse(input);
+  const expected = [{
+    type: 'embed',
+    embedType: 'twitter',
+    embedAs: 'video',
     caption: [],
     text: [
       { content: 'GIF vs. JIF… This ', href: null },
@@ -390,6 +414,7 @@ test('parse() tweet - no date', t => {
   const expected = [{
     type: 'embed',
     embedType: 'twitter',
+    embedAs: 'tweet',
     caption: [],
     text: [
       { content: 'GIF vs. JIF… This ', href: null },
@@ -421,6 +446,7 @@ test('parse() tweet - no paragraph, no user', t => {
   const expected = [{
     type: 'embed',
     embedType: 'twitter',
+    embedAs: 'tweet',
     caption: [],
     text: [],
     url: 'https://twitter.com/MattNavarra/status/684690494841028608',


### PR DESCRIPTION
referenced micnews/embeds#24 - expose embedAs object key for twitter video embeds.

Depends on [PR#30](https://github.com/micnews/embeds/pull/30) 
