### PR TITLE
render mark tags with empty textnode

### DIFF
--- a/lib/parse/index.js
+++ b/lib/parse/index.js
@@ -10,6 +10,8 @@ const HEAD_NODE_NAMES = new Set([
 
 const linebreak = elm => elm.tagName.toLowerCase() === 'br' ? { type: 'linebreak' } : null;
 
+const isEmptyTextNode = elm => (elm.nodeName === '#text' && elm.data.length === 0);
+
 export default opts => {
   const text = setupText(opts);
   const embed = setupEmbed(opts);
@@ -52,7 +54,9 @@ export default opts => {
       return;
     }
 
-    const emptyMark = elm.tagName.toLowerCase() === 'mark' && elm.childNodes.length === 0;
+    const emptyMark = elm.tagName.toLowerCase() === 'mark' &&
+      (elm.childNodes.length === 0 ||
+      elm.childNodes.length === 1 && isEmptyTextNode(elm.childNodes[0]));
     if (emptyMark) {
       result.push(text(textOpts, elm));
       return;

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -922,3 +922,32 @@ test('parse() strikethrough', t => {
     t.same(actual, expected);
   });
 });
+
+if (process.browser) {
+  test('parse() empty mark with empty text node', t => {
+    const emptyTextNode = document.createTextNode('');
+    const emptyMark = document.createElement('mark');
+    const paragraph = document.createElement('p');
+
+    emptyMark.appendChild(emptyTextNode);
+    paragraph.appendChild(emptyMark);
+    document.body.appendChild(paragraph);
+
+    const actual = _parse(paragraph);
+    const expected = [{
+      type: 'paragraph',
+      children: [{
+        type: 'text',
+        content: null,
+        href: null,
+        italic: false,
+        bold: false,
+        mark: true,
+        markClass: null,
+        strikethrough: false
+      }]
+    }];
+
+    t.same(actual, expected);
+  });
+}


### PR DESCRIPTION
Review: @iefserge 
Type: Patch

For some reason a empty textnode is added to the marktag in the scenario in the failing test in here: https://github.com/micnews/article-json-to-contenteditable/pull/23 I can't figure out exactly why, but added a test with that behaviour at least. This update should fix the failing test in `article-json-to-contenteditable`. 
