### PR TITLE
Fix crash when block child content is null

### DIFF
--- a/lib/normalize/flatten-tree.js
+++ b/lib/normalize/flatten-tree.js
@@ -1,4 +1,4 @@
-const rowHasContent = row => row.content.trim().length > 0;
+const rowHasContent = row => row.content && row.content.trim().length > 0;
 const rowHasSize = row => row.type === 'linebreak' || rowHasContent(row);
 const hasSize = inlineElements => inlineElements.some(rowHasSize);
 

--- a/test/normalize-test.js
+++ b/test/normalize-test.js
@@ -182,3 +182,14 @@ test('normalize() don\'t remove br tags in-between mark with content', t => {
 
   t.same(actual, expected);
 });
+
+test('normalize() content = null in block child', t => {
+  const tree = [{
+    type: 'block',
+    children: [{
+      type: 'text',
+      content: null
+    }]
+  }];
+  t.doesNotThrow(() => normalize(tree));
+});


### PR DESCRIPTION
`content` is sometimes null and null does not have method `trim()`

Type: Patch
Review: @iefserge @danmakenoise 
